### PR TITLE
Add basic Jest tests for combat logic

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'node',
+};

--- a/js/combat.js
+++ b/js/combat.js
@@ -108,4 +108,6 @@ export function fightEnemy(enemy, offenseSkillName = 'Attack') {
   UI.renderPlayer();
   UI.renderSkills();
   UI.renderQuests();
+
+  return { dealt: totalDealt, taken: totalTaken };
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "daburgermeista-s-games",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}

--- a/tests/combat.test.js
+++ b/tests/combat.test.js
@@ -1,0 +1,28 @@
+import { fightEnemy, Enemy } from '../js/combat.js';
+import { player } from '../js/player.js';
+import { Skills } from '../js/skills.js';
+
+describe('fightEnemy', () => {
+  beforeEach(() => {
+    // reset player and skills
+    player.health = player.maxHealth;
+    player.xp = 0;
+    player.stats.strength = 1;
+    const attackSkill = Skills.find(s => s.name === 'Attack');
+    const defenseSkill = Skills.find(s => s.name === 'Defense');
+    if (attackSkill) { attackSkill.xp = 0; attackSkill.level = 1; }
+    if (defenseSkill) { defenseSkill.xp = 0; defenseSkill.level = 1; }
+  });
+
+  test('returns numeric damage totals and updates XP', () => {
+    const enemy = new Enemy({ id: 99, name: 'Dummy', stats: { attack: 0, defense: 0 }, maxHp: 5, goldReward: 0 });
+    const result = fightEnemy(enemy, 'Attack');
+    expect(typeof result.dealt).toBe('number');
+    expect(typeof result.taken).toBe('number');
+
+    const attackSkill = Skills.find(s => s.name === 'Attack');
+    const defenseSkill = Skills.find(s => s.name === 'Defense');
+    expect(attackSkill.xp).toBeGreaterThan(0);
+    expect(defenseSkill.xp).toBe(0); // enemy attack is 0
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest setup and package.json
- return combat totals from `fightEnemy`
- add unit test for combat damage and XP logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ace03f3fc83299badbea3ec2087d0