### PR TITLE
fix: return damage from takeDamage to prevent NaN

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -55,9 +55,11 @@ export class Player {
 
   takeDamage(amount) {
     const damage = Math.max(amount - (this.stats.defense || 0), 0);
+    const prevHealth = this.health;
     this.health = Math.max(this.health - damage, 0);
+    const actual = prevHealth - this.health;
     if (this.health === 0) this.onDeath();
-    return damage;
+    return actual;
   }
 
   heal(amount) {


### PR DESCRIPTION
## Summary
- return actual damage from `takeDamage`
- use returned damage in combat when adding totals

## Testing
- `node - <<'NODE'
const stub = () => {};
global.window = {addEventListener: stub};
global.document = {getElementById: ()=>({}), createElement: ()=>({append(){}})};
Object.defineProperty(global, 'localStorage', {value:{getItem:()=>null,setItem:()=>{}}});
(async () => {
  const {player} = await import('./js/player.js');
  player.stats.defense = 0;
  player.health = 5;
  let damage = player.takeDamage(10);
  console.log('returned', damage, 'new health', player.health);
})();
NODE

------
https://chatgpt.com/codex/tasks/task_e_684acdec7acc83298f86f8f8bd7b9409