### PR TITLE
Improve skill UI and display gold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 Folder-Structure.txt
+node_modules/
+package-lock.json

--- a/css/style.css
+++ b/css/style.css
@@ -86,6 +86,13 @@ main {
   margin-top: 5px;
 }
 
+.skill-item .xp {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.8rem;
+  color: #555;
+}
+
 .skill-item .fill {
   height: 100%;
   width: 0%;

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
       <p>Level: <span id="player-level">1</span></p>
       <p>XP: <span id="player-xp">0</span> / <span id="player-xp-next">100</span></p>
       <p>HP: <span id="player-hp">100</span> / <span id="player-maxhp">100</span></p>
+      <p>Gold: <span id="player-gold">0</span></p>
     </section>
 
     <!-- Skills List -->

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,3 @@
 export default {
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
 };

--- a/js/player.js
+++ b/js/player.js
@@ -8,6 +8,7 @@ export class Player {
     name = 'Hero',
     level = 1,
     xp = 0,
+    gold = 0,
     stats = { strength: 1, dexterity: 1, intelligence: 1 },
     health = 100,
     maxHealth = 100,
@@ -17,6 +18,7 @@ export class Player {
     this.name = name;
     this.level = level;
     this.xp = xp;
+    this.gold = gold;
     this.stats = stats;
     this.health = health;
     this.maxHealth = maxHealth;
@@ -101,6 +103,7 @@ export class Player {
       name: this.name,
       level: this.level,
       xp: this.xp,
+      gold: this.gold,
       stats: this.stats,
       health: this.health,
       maxHealth: this.maxHealth,
@@ -115,4 +118,4 @@ export class Player {
 }
 
 // Singleton player instance
-export const player = new Player({ name: 'Hero' });
+export const player = new Player({ name: 'Hero', gold: 0 });

--- a/js/ui.js
+++ b/js/ui.js
@@ -23,6 +23,7 @@ export const UI = {
     this.xpNextEl = document.getElementById('player-xp-next');
     this.hpEl = document.getElementById('player-hp');
     this.maxHpEl = document.getElementById('player-maxhp');
+    this.goldEl = document.getElementById('player-gold');
     this.skillListEl = document.getElementById('skill-list');
     this.questListEl = document.getElementById('quest-list');
     this.combatViewEl = document.getElementById('combat-view');
@@ -33,15 +34,18 @@ export const UI = {
   },
 
   renderPlayer() {
+    if (!this.nameEl) return;
     this.nameEl.textContent = player.name;
     this.levelEl.textContent = player.level;
     this.xpEl.textContent = Math.floor(player.xp);
     this.xpNextEl.textContent = player.xpForNext();
     this.hpEl.textContent = player.health;
     this.maxHpEl.textContent = player.maxHealth;
+    if (this.goldEl) this.goldEl.textContent = player.gold || 0;
   },
 
   renderSkills() {
+    if (!this.skillListEl) return;
     this.skillListEl.innerHTML = '';
     Skills.forEach(skill => {
       const li = document.createElement('li');
@@ -50,13 +54,30 @@ export const UI = {
         <div class="info">
           <span class="name">${skill.name} (Lv ${skill.level})</span>
           <div class="bar"><div class="fill" style="width: ${this.fillPercent(skill)}%;"></div></div>
+          <span class="xp">${Math.floor(skill.xp)} / ${skill.xpForNext()}</span>
         </div>
       `;
+
+      const btn = document.createElement('button');
+      btn.className = 'train-btn';
+      btn.textContent = skill.isTraining ? 'Stop' : 'Train';
+      if (skill.isTraining) btn.classList.add('active');
+      btn.addEventListener('click', () => {
+        if (skill.isTraining) {
+          skill.stopTraining();
+        } else {
+          skill.startTraining();
+        }
+        this.renderSkills();
+      });
+
+      li.append(btn);
       this.skillListEl.append(li);
     });
   },
 
   renderQuests() {
+    if (!this.questListEl) return;
     this.questListEl.innerHTML = '';
     Quests.forEach(q => {
       const li = document.createElement('li');
@@ -114,6 +135,8 @@ export const UI = {
   },
 
   showNotification(msg) {
+    if (!this.notificationEl) return;
+
     const el = document.createElement('div');
     el.textContent = msg;
     this.notificationEl.append(el);

--- a/package.json
+++ b/package.json
@@ -5,12 +5,15 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "jest": "^29.0.0"
+  },
+  "dependencies": {
+    "jest-environment-jsdom": "^30.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add training buttons and XP progress for skills
- show player gold on the info panel
- store gold in player data
- support jsdom in tests and update test script
- ignore node_modules and package-lock

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ad0cca9e08329acddc261a6b2d7e7